### PR TITLE
docs: document bun workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,34 @@
+# AGENTS
+
+Use [Bun](https://bun.sh) for dependency management and running scripts.
+
+## Setup
+
+- Install dependencies: `bun install`
+
+## Formatting
+
+- Fix formatting: `bun run prettier:write`
+- Check formatting: `bun run prettier:check`
+
+## Linting
+
+- Fix lint issues: `bun run lint`
+- Check linting: `bun run lint:check`
+
+## Type Checking
+
+- TypeScript no-emit checks: `bun run typecheck`
+
+## Tests
+
+- End-to-end tests: `bun run test:e2e`
+- Interactive mode: `bun run test:e2e:ui`
+- Open last report: `bun run test:e2e:report`
+- One-time browser install: `bun run test:e2e:install`
+
+## Build
+
+- Build the app: `bun run build`
+
+After code changes, run formatting check, lint check, typecheck, tests, and build to verify everything works.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,15 @@
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
     "dev": "next dev",
-    "lint": "next lint",
+    "lint": "next lint --fix",
+    "lint:check": "next lint",
+    "prettier:write": "prettier --write .",
+    "prettier:check": "prettier --check .",
+    "typecheck": "tsc --noEmit",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report",
+    "test:e2e:install": "playwright install",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- document development commands for Bun in AGENTS.md
- add missing scripts for formatting, linting, type-checking and E2E tests

## Testing
- `bun run lint:check`
- `bun run prettier:check` *(fails: Code style issues found in 9 files)*
- `bun run typecheck`
- `bun run test:e2e` *(fails: playwright: command not found)*
- `bun run build`


------
https://chatgpt.com/codex/tasks/task_e_68c17e3cf5008329875a85afdad2b0a5