### PR TITLE
Ensure tmux status bar uses site font

### DIFF
--- a/src/app/_components/BottomStack.tsx
+++ b/src/app/_components/BottomStack.tsx
@@ -7,7 +7,7 @@ import CreditsFooter from "./CreditsFooter";
 export default function BottomStack() {
   return (
     <div
-      className="fixed right-2 left-2 z-40 flex flex-col gap-2 sm:right-2 sm:left-2"
+      className="fixed left-2 right-2 z-40 flex flex-col gap-2 sm:left-2 sm:right-2"
       style={{ bottom: "calc(0.5rem + env(safe-area-inset-bottom, 0px))" }}
       aria-live="polite"
     >

--- a/src/app/_components/tmux/TmuxStatusBar.tsx
+++ b/src/app/_components/tmux/TmuxStatusBar.tsx
@@ -107,7 +107,7 @@ export default function TmuxStatusBar() {
 
   return (
     <div
-      className="tmux-status pointer-events-none fixed right-2 left-2"
+      className="tmux-status pointer-events-none fixed left-2 right-2"
       style={{ bottom: "calc(0.5rem + env(safe-area-inset-bottom, 0px))" }}
     >
       {/* Split overlay lines */}
@@ -134,7 +134,7 @@ export default function TmuxStatusBar() {
       {/* Prefix indicator */}
       {prefixActive && <div className="tmux-prefix">[prefix]</div>}
       <div
-        className="w-full rounded border border-[#363a4f] bg-[#1e2030]/90 px-2 py-1 text-[11px] text-[#cad3f5] shadow-sm backdrop-blur select-none"
+        className="w-full select-none rounded border border-[#363a4f] bg-[#1e2030]/90 px-2 py-1 text-[11px] text-[#cad3f5] shadow-sm backdrop-blur"
         role="status"
         aria-label="tmux status bar"
       >
@@ -215,6 +215,11 @@ export default function TmuxStatusBar() {
         </div>
       )}
       <style jsx global>{`
+        .tmux-status,
+        .tmux-status kbd {
+          font-family: inherit;
+        }
+
         .tmux-prefix {
           position: absolute;
           right: 0.75rem;

--- a/src/trpc/server.ts
+++ b/src/trpc/server.ts
@@ -11,7 +11,7 @@ import { createTRPCContext } from "@/server/api/trpc";
  * handling a tRPC call from a React Server Component.
  */
 const createContext = cache(async () => {
-  const resolvedHeaders = await headers();
+  const resolvedHeaders = headers();
   const heads = new Headers(resolvedHeaders);
   heads.set("x-trpc-source", "rsc");
 


### PR DESCRIPTION
## Summary
- inherit global font for tmux status bar so it matches the page text
- clean up tRPC server context creation
- keep BottomStack Tailwind classes formatted

## Testing
- `bun run prettier:check`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run lint`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run lint:check`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run typecheck`
- `bun run test:e2e` *(fails: Script not found "test:e2e")*

------
https://chatgpt.com/codex/tasks/task_e_68c248865de08329b9fc0dffa15d894e