### PR TITLE
Ensure tmux status bar uses site font

### DIFF
--- a/src/app/_components/tmux/TmuxStatusBar.tsx
+++ b/src/app/_components/tmux/TmuxStatusBar.tsx
@@ -215,6 +215,11 @@ export default function TmuxStatusBar() {
         </div>
       )}
       <style jsx global>{`
+        .tmux-status,
+        .tmux-status kbd {
+          font-family: inherit;
+        }
+
         .tmux-prefix {
           position: absolute;
           right: 0.75rem;


### PR DESCRIPTION
## Summary
- inherit global font for tmux status bar so it matches the page text
- await `headers()` in tRPC context to satisfy build
- sort Tailwind classes in BottomStack and tmux status bar

## Testing
- `bun run prettier:check`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run lint`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run lint:check`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run typecheck`
- `DATABASE_URL=file:./db.sqlite bun run build`
- `bun run test:e2e` *(fails: Script not found "test:e2e")*

------
https://chatgpt.com/codex/tasks/task_e_68c248865de08329b9fc0dffa15d894e