### PR TITLE
Add analytics tracking with Umami

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,8 @@ DATABASE_URL="file:./db.sqlite"
 # Example:
 # SERVERVAR="foo"
 # NEXT_PUBLIC_CLIENTVAR="bar"
+
+# Analytics
+# Example Umami configuration
+NEXT_PUBLIC_UMAMI_WEBSITE_ID=""
+NEXT_PUBLIC_UMAMI_SCRIPT_URL="https://us.umami.is/script.js"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ cp .env.example .env.local
 # open .env.local and fill required values
 ```
 
+The following environment variables are supported:
+
+- `NEXT_PUBLIC_UMAMI_WEBSITE_ID` – Umami website ID.
+- `NEXT_PUBLIC_UMAMI_SCRIPT_URL` – URL to the Umami tracking script.
+
 3. Database (Drizzle)
 
 ```

--- a/src/app/_components/Analytics.tsx
+++ b/src/app/_components/Analytics.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Script from "next/script";
+import { useEffect } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { env } from "@/env";
+
+declare global {
+  interface Window {
+    umami?: {
+      track: (event: string, data?: Record<string, unknown>) => void;
+      trackView?: (url: string) => void;
+    };
+  }
+}
+
+export function Analytics() {
+  const websiteId = env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+  const scriptUrl = env.NEXT_PUBLIC_UMAMI_SCRIPT_URL;
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (!websiteId) return;
+    const search = searchParams.toString();
+    const url = pathname + (search ? `?${search}` : "");
+    window.umami?.trackView?.(url);
+  }, [websiteId, pathname, searchParams]);
+
+  useEffect(() => {
+    if (!websiteId) return;
+    function handleClick(e: MouseEvent) {
+      const target = e.target as Element | null;
+      if (!target) return;
+      const anchor = target.closest("a");
+      if (anchor instanceof HTMLAnchorElement && anchor.href) {
+        window.umami?.track("link_click", { href: anchor.href });
+      }
+    }
+    document.addEventListener("click", handleClick);
+    return () => document.removeEventListener("click", handleClick);
+  }, [websiteId]);
+
+  if (!websiteId || !scriptUrl) return null;
+
+  return (
+    <Script
+      src={scriptUrl}
+      data-website-id={websiteId}
+      strategy="afterInteractive"
+    />
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "@/styles/globals.css";
 import { GeistSans } from "geist/font/sans";
 
 import { TRPCReactProvider } from "@/trpc/react";
+import { Analytics } from "./_components/Analytics";
 
 export const metadata = {
   title: "Jordan Garcia",
@@ -20,6 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${GeistSans.variable}`}>
       <body>
+        <Analytics />
         <TRPCReactProvider>{children}</TRPCReactProvider>
       </body>
     </html>

--- a/src/env.js
+++ b/src/env.js
@@ -19,7 +19,8 @@ export const env = createEnv({
    * `NEXT_PUBLIC_`.
    */
   client: {
-    // NEXT_PUBLIC_CLIENTVAR: z.string(),
+    NEXT_PUBLIC_UMAMI_WEBSITE_ID: z.string().optional(),
+    NEXT_PUBLIC_UMAMI_SCRIPT_URL: z.string().url().optional(),
   },
 
   /**
@@ -29,7 +30,8 @@ export const env = createEnv({
   runtimeEnv: {
     DATABASE_URL: process.env.DATABASE_URL,
     NODE_ENV: process.env.NODE_ENV,
-    // NEXT_PUBLIC_CLIENTVAR: process.env.NEXT_PUBLIC_CLIENTVAR,
+    NEXT_PUBLIC_UMAMI_WEBSITE_ID: process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID,
+    NEXT_PUBLIC_UMAMI_SCRIPT_URL: process.env.NEXT_PUBLIC_UMAMI_SCRIPT_URL,
   },
   /**
    * Run `build` or `dev` with `SKIP_ENV_VALIDATION` to skip env validation. This is especially


### PR DESCRIPTION
## Summary
- integrate Umami analytics to track page views and link clicks
- document `NEXT_PUBLIC_UMAMI_WEBSITE_ID` and `NEXT_PUBLIC_UMAMI_SCRIPT_URL` env vars

## Testing
- `bun run prettier:check`
- `bun run lint`
- `bun run lint:check`
- `bun run typecheck`
- `bun run test:e2e` *(fails: Script not found "test:e2e")*

------
https://chatgpt.com/codex/tasks/task_e_68c2dda55ad8832981dd06bb083b0bfe