### PR TITLE
docs: add build verification step

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ These instructions apply to the entire repository.
 - Format code with `bun run prettier:write` and verify using `bun run prettier:check`.
 - Lint with `bun run lint` and verify using `bun run lint:check`.
 - Run the type checker with `bun run typecheck`.
+- Verify the build with `bun run build`.
 - Execute end-to-end tests with `bun run test:e2e` (install browsers once via `bun run test:e2e:install`).
 
 Ensure these commands pass before committing changes.


### PR DESCRIPTION
## Summary
- require contributors to run `bun run build` before committing

## Testing
- `bun run prettier:write AGENTS.md`
- `bun run prettier:check AGENTS.md`
- `bun run lint`
- `bun run lint:check`
- `bun run typecheck`
- `bun run build`
- `bun run test:e2e` *(fails: Script not found "test:e2e")*

------
https://chatgpt.com/codex/tasks/task_e_68c40c0b05d083298f35d4290c445813