### PR TITLE
docs: quiet verification command logs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,3 +10,8 @@ These instructions apply to the entire repository.
 - Execute end-to-end tests with `bun run test:e2e` (install browsers once via `bun run test:e2e:install`).
 
 Ensure these commands pass before committing changes.
+
+## Logging
+
+- When running verification commands, silence standard output so only errors are shown by redirecting stdout to `/dev/null` (e.g., `bun run lint:check >/dev/null`).
+- You may run the same commands without redirection to view full logs.


### PR DESCRIPTION
## Summary
- instruct contributors to redirect command output to `/dev/null` when running verification steps to surface only errors

## Testing
- `bun run prettier:write >/dev/null`
- `bun run prettier:check >/dev/null`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run lint >/dev/null`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run lint:check >/dev/null`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run typecheck >/dev/null`
- `DATABASE_URL=postgresql://user:pass@localhost:5432/db bun run test:e2e >/dev/null` *(fails: Script not found "test:e2e")*

------
https://chatgpt.com/codex/tasks/task_e_68c41b311d088329a0e48a8e1eec8ffb