### PR TITLE
chore: ignore local.db dev database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,10 @@
 /prisma/db.sqlite
 /prisma/db.sqlite-journal
 db.sqlite
+local.db
+local.db-shm
+local.db-wal
+local.db-journal
 
 # next.js
 /.next/


### PR DESCRIPTION
## Summary
- Add `local.db` (and its `-shm`/`-wal`/`-journal` sidecars) to `.gitignore` so the local Drizzle/libSQL dev database can't be accidentally committed.

## Context
The repo's `.gitignore` database block still carried Prisma-era paths (`/prisma/db.sqlite`) after the migration to Drizzle/libSQL, leaving the actual dev DB (`local.db`, pointed to by `DATABASE_URL`) untracked-but-not-ignored. A stray `git add .` would have committed it.

Also removed a stray untracked `package-lock.json` from the working tree (not part of this commit) — this is a Bun project; `bun.lock` is the canonical lockfile.

## Test plan
- `git check-ignore -v local.db` matches the new rule.
- `git status` is clean; `local.db` no longer appears as untracked.